### PR TITLE
update docker file to use node:16-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ ENV NODE_ENV build
 USER node
 WORKDIR /home/node
 
-COPY --chown=node:node . .
+COPY package*.json ./
+RUN npm ci
 
-RUN npm ci \
-    && npm run build \
+COPY --chown=node:node . .
+RUN npm run build \
     && npm prune --production
 
 # ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@
 # https://www.bretfisher.com/node-docker-good-defaults/
 # http://goldbergyoni.com/checklist-best-practice-of-node-js-in-production/
 
-FROM node:14-alpine as builder
+FROM node:16-alpine as builder
 
 ENV NODE_ENV build
 
 USER node
 WORKDIR /home/node
 
-COPY . /home/node
+COPY --chown=node:node . .
 
 RUN npm ci \
     && npm run build \
@@ -28,7 +28,7 @@ RUN npm ci \
 
 # ---
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 ENV NODE_ENV production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ ENV NODE_ENV production
 USER node
 WORKDIR /home/node
 
-COPY --from=builder /home/node/package*.json /home/node/
-COPY --from=builder /home/node/node_modules/ /home/node/node_modules/
-COPY --from=builder /home/node/dist/ /home/node/dist/
+COPY --from=builder --chown=node:node /home/node/package*.json ./
+COPY --from=builder --chown=node:node /home/node/node_modules/ ./node_modules/
+COPY --from=builder --chown=node:node /home/node/dist/ ./dist/
 
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION
1. updated to `node:16-alpine`
2. `node_modules` are cached in a separate docker layer
3. `--chown=node:node` is used to fix ownership while copying files
4. After setting  `WORKDIR /home/node` that path is no longer required in destination paths since destination paths are relative to workDir.