### PR TITLE
Fix SyntaxError when running npm run migration:run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "build": "npm run clean && tsc",
     "test": "env-cmd -f .env jest --config=jest.json",
     "lint": "tslint -p tsconfig.json -c tslint.json 'src/**/*.ts'",
-    "migration:create": "env-cmd -f .env ts-node ./node_modules/.bin/typeorm migration:create -n",
-    "migration:run": "env-cmd -f .env ts-node ./node_modules/.bin/typeorm migration:run",
-    "migration:revert": "env-cmd -f .env ts-node ./node_modules/.bin/typeorm migration:revert"
+    "migration:create": "env-cmd -f .env ts-node ./node_modules/typeorm/cli.js migration:create -n",
+    "migration:run": "env-cmd -f .env ts-node ./node_modules/typeorm/cli.js migration:run",
+    "migration:revert": "env-cmd -f .env ts-node ./node_modules/typeorm/cli.js migration:revert"
   },
   "dependencies": {
     "joi": "^17.5.0",


### PR DESCRIPTION
This fixes the following error when running `npm run migration:run` on Windows:

```
C:\src\nestjs-template > npm run migration:run

> nest-template@0.1.0 migration:run
> env-cmd -f .env ts-node ./node_modules/.bin/typeorm migration:run

C:\src\nestjs-template\node_modules\.bin\typeorm:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1031:15)
    at Module._compile (node:internal/modules/cjs/loader:1065:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Object.require.extensions.<computed> [as .js] (C:\src\nestjs-template\node_modules\ts-node\src\index.ts:1361:43)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at main (C:\src\nestjs-template\node_modules\ts-node\src\bin.ts:331:12)
    at Object.<anonymous> (C:\src\nestjs-template\node_modules\ts-node\src\bin.ts:482:3)
```

See [this issue](https://github.com/typeorm/typeorm/issues/317).